### PR TITLE
Fix Scrolling Issues

### DIFF
--- a/stylesheets/_normalize.scss
+++ b/stylesheets/_normalize.scss
@@ -2,6 +2,7 @@
 
 html {
   -webkit-text-size-adjust: 100%;
+  overflow-x: hidden;
 }
 
 body {

--- a/stylesheets/_wordpress.scss
+++ b/stylesheets/_wordpress.scss
@@ -440,3 +440,9 @@ object {
 .gallery-caption {
 	display: block;
 }
+
+/** === Related Posts === */
+
+.jp-relatedposts-post-title a {
+    word-break: break-word;
+}


### PR DESCRIPTION
There's currently a few scrolling issues with the Business Theme, both on the demo and individual sites. This PR intends to fix those.

On the demo, you'll see that on larger screens, a scrolling bar appears on the bottom. This does not benefit the site, but is just a bit of a nuisance. 
![hfdgdfghdfghgfh](https://user-images.githubusercontent.com/43215253/48966613-e3433700-efcc-11e8-9afd-a073381f1707.png)

This is also the case with some posts when Related Posts is enabled, and one of those posts has a long title. 

![gsdfsdfgsfdg](https://user-images.githubusercontent.com/43215253/48966618-04a42300-efcd-11e8-8844-4a17062b5748.png)

So I've also adjusted related posts so that the scrolling issue should not appear, but this should happen with longer titles instead. 

![sgdfdgfsdfg](https://user-images.githubusercontent.com/43215253/48966625-31f0d100-efcd-11e8-94a8-2ffdf84580cb.png)

This also should take care of the scrolling issue when a cover image is inserted using Gutenberg. Currently, there is the unnecessary option to scroll at the bottom. 

![sdgfsdfgsdgsdfg](https://user-images.githubusercontent.com/43215253/48982248-e7a84680-f0d7-11e8-9d66-1af10e776322.png)

Would appreciate all feedback on these changes (cc @allancole & @mendezcode) - this is my first PR here and I hope I'm not doing anything wrong, so please let me know if I am! 
