### PR TITLE
Update cover block classes to remove the 'image'

### DIFF
--- a/css/blocks.scss
+++ b/css/blocks.scss
@@ -224,9 +224,9 @@
 	text-align: right;
 }
 
-// !Cover image
+// !Cover
 
-.wp-block-cover-image {
+.wp-block-cover {
 	width: inherit;
 
 	@include media( tablet ) {
@@ -247,7 +247,7 @@
 		margin-left: $x-space-md;
 	}
 
-	.wp-block-cover-image-text,
+	.wp-block-cover-text,
 	h2 {
 		font-weight: 400;
 		padding: $x-space-md;
@@ -263,8 +263,8 @@
 	}
 }
 
-[data-align=left] .wp-block-cover-image,
-[data-align=right] .wp-block-cover-image {
+[data-align=left] .wp-block-cover,
+[data-align=right] .wp-block-cover {
 
 	max-width: 285px;
 


### PR DESCRIPTION
In the block editor, the Cover Image block was renamed to just Cover, to match it allowing more than images (Cover Videos!). With that, the classes were updated. This PR removes the `-image` from the `.wp-block-cover` and `.wp-block-cover-text` classes. 

Fixes #17.