### PR TITLE
Business editor styles rewrite

### DIFF
--- a/css/blocks.scss
+++ b/css/blocks.scss
@@ -36,12 +36,9 @@
 
 		.alignfull {
 			position: relative;
-			transform: translateX( -50% );
-			width: 100vw;
-			max-width: 100vw;
-			margin-top: 1em;
-			margin-bottom: 1em;
-			left: 50%;
+			min-width: 100vw;
+			margin-left: 50%;
+			left: -50vw;
 		}
 	}
 	
@@ -347,10 +344,6 @@
 	@include media( tablet ) {
 		padding-left: $x-space-lg;
 		padding-right: $x-space-lg;
-		&.alignfull {
-			padding-left: $x-space-sm;
-			padding-right: $x-space-sm;
-		}
 	}
 }
 

--- a/css/blocks.scss
+++ b/css/blocks.scss
@@ -629,10 +629,9 @@ table.wp-block-table {
 .wp-block-file {
 	
 	> a:first-child {
-		color: inherit;
-		box-shadow: none;
+		@include link-underline;
 		&:hover {
-			text-decoration: underline;
+			text-decoration: none;
 		}
 	}
 	

--- a/css/blocks.scss
+++ b/css/blocks.scss
@@ -121,35 +121,18 @@
 // !Buttons
 
 .wp-block-file .wp-block-file__button,
-.wp-block-button .wp-block-button__link{
+.wp-block-button .wp-block-button__link {
+	@include button-style;
+}
 
-	background-color: $x-color-accent-base;
-	color: $x-color-shade-white;
-	padding: $x-space-xxs $x-space-xs;
-	font-size: $x-font-size-sm;
-	line-height: $x-font-leading-body;
-	letter-spacing: $x-font-letter-spacing;
-	@include rounded( 3px );
-	border: 0;
-	cursor: pointer;
-	display: inline-block;
-	font-weight: 600;
-	text-decoration: none;
-	text-transform: uppercase;
-	vertical-align: middle;
+.wp-block-button.is-style-squared .wp-block-button__link  {
+	border-radius: 0;
+}
 
-	&:hover {
-		background-color: $x-color-accent-light;
-	}
-
-	&:active,
-	&:focus {
-		background-color: $x-color-accent-light;
-	}
-
-	@include media( tablet ) {
-		padding: $x-space-xs $x-space-sm;
-	}
+.wp-block-button.is-style-outline .wp-block-button__link {
+	background: transparent;
+	border: solid 2px $x-color-accent-base;
+	color: $x-color-accent-base;
 }
 
 // !Audio
@@ -319,15 +302,15 @@
 	justify-content: space-between;
 
 	&.has-2-columns .wp-block-column {
-		width: calc( 50% - ( $x-space-gutter * .5 ) );
+		width: calc(50% - ( #{$x-space-gutter} * .5 ));
 	}
 
 	&.has-3-columns .wp-block-column {
-		width: calc( 33% - ( $x-space-gutter * .33 ) );
+		width: calc(33% - ( #{$x-space-gutter} * 0.33));
 	}
 
 	&.has-4-columns .wp-block-column {
-		width: calc( 25% - ( $x-space-gutter * .25 ) );
+		width: calc(25% - ( #{$x-space-gutter} * .25 ));
 	}
 
 }

--- a/css/blocks.scss
+++ b/css/blocks.scss
@@ -344,6 +344,10 @@
 	@include media( tablet ) {
 		padding-left: $x-space-lg;
 		padding-right: $x-space-lg;
+		&.is-grid {
+			padding-left: $x-space-md;
+			padding-right: $x-space-md;
+		}
 	}
 }
 

--- a/css/blocks.scss
+++ b/css/blocks.scss
@@ -347,6 +347,10 @@
 	@include media( tablet ) {
 		padding-left: $x-space-lg;
 		padding-right: $x-space-lg;
+		&.alignfull {
+			padding-left: $x-space-sm;
+			padding-right: $x-space-sm;
+		}
 	}
 }
 
@@ -370,6 +374,11 @@ ol.wp-block-latest-comments {
 	li li {
 		font-size: 1em;
 	}
+	
+	&.aligncenter li {
+		text-align: center;
+		list-style-position: inside;
+	}
 
 	&.is-grid {
 		justify-content: space-between;
@@ -386,7 +395,8 @@ ol.wp-block-latest-comments {
 		}
 	}
 }
-ol.wp-block-latest-comments {
+
+.wp-block-latest-comments {
 	
 	> li:before {
 		content: '';
@@ -399,6 +409,7 @@ ol.wp-block-latest-comments {
 			padding-left: $x-space-md;
 		}			
 	}
+	
 }
 
 .wp-block-latest-comments__comment-excerpt {

--- a/css/blocks.scss
+++ b/css/blocks.scss
@@ -251,6 +251,7 @@
 	}
 
 	.wp-block-cover-text,
+	.wp-block-cover-image-text,
 	h2 {
 		font-weight: 400;
 		padding: $x-space-md;
@@ -267,7 +268,9 @@
 }
 
 [data-align=left] .wp-block-cover,
-[data-align=right] .wp-block-cover {
+[data-align=left] .wp-block-cover-image,
+[data-align=right] .wp-block-cover,
+[data-align=right] .wp-block-cover-image {
 
 	max-width: 285px;
 

--- a/css/blocks.scss
+++ b/css/blocks.scss
@@ -16,13 +16,22 @@
 
 	@include media( tablet ) {
 		.alignwide {
+
+			$width: 1235px;
+			$sep: 18px;
+
+			min-width: $width;
 			position: relative;
-			width: $x-space-column-12;
-			transform: translateX( -50% );
-			max-width: calc( 100vw - 2 * 1em );
 			margin-top: 1em;
 			margin-bottom: 1em;
-			left: 50%;
+			margin-left: calc( -1 * ( #{$width} - #{$x-grid-column-7} ) / 2 );
+			
+			@media only screen and (min-width: $tablet_width) and (max-width: ($width + 2 * $sep ) ) {
+				margin-left: calc( -1 * ( 100vw - #{$x-grid-column-7} ) / 2 + #{$sep} );
+				width: 100vw;
+				min-width: initial;
+				max-width: calc( 100vw - 2 * #{$sep} );
+			}
 		}
 
 		.alignfull {
@@ -222,7 +231,9 @@
 
 // !Cover image
 
-.wp-block-cover-image {
+.wp-block-cover,
+.wp-block-cover-image,
+ {
 	width: inherit;
 
 	@include media( tablet ) {

--- a/css/blocks.scss
+++ b/css/blocks.scss
@@ -138,6 +138,10 @@
 // !Audio
 
 .wp-block-audio {
+	
+	figcaption {
+		text-align: center !important;
+	}
 
 	audio {
 		width: 100%;

--- a/css/blocks.scss
+++ b/css/blocks.scss
@@ -180,6 +180,10 @@
 		}
 	}
 	
+	figcaption {
+		text-align: center !important;
+	}
+	
 	.alignleft,
 	.aligncenter,
 	.alignright {

--- a/css/blocks.scss
+++ b/css/blocks.scss
@@ -133,6 +133,11 @@
 	background: transparent;
 	border: solid 2px $x-color-accent-base;
 	color: $x-color-accent-base;
+	
+	&:hover {
+		background: $x-color-accent-base;
+		color: white;
+	}
 }
 
 // !Audio

--- a/editor.scss
+++ b/editor.scss
@@ -534,6 +534,10 @@ p.has-drop-cap:not(:focus)::first-letter {}
 			color: $x-color-secondary-base;
 		}
 	}
+	[data-align="full"] &.is-grid {
+		padding-left: $x-space-sm;
+		padding-right: $x-space-sm;
+	}
 }
 
 /* Categories, Latest Posts & Archives */
@@ -542,6 +546,7 @@ p.has-drop-cap:not(:focus)::first-letter {}
 [data-align="center"] ul.wp-block-latest-posts,
 [data-align="center"] ul.wp-block-archives {
 	list-style-position: inside; /* makes sure bullets are centred with centred lists */
+	padding-left: 0;
 }
 
 /* Latest Comments */
@@ -561,7 +566,9 @@ p.has-drop-cap:not(:focus)::first-letter {}
 }
 
 .wp-block-latest-comments__comment-meta a {
-	/* change comment author name and post title styles */
+	color: $x-color-secondary-base;
+	font-size: $x-font-size-md;
+	text-decoration: underline;
 }
 
 .wp-block-latest-comments__comment-date {

--- a/editor.scss
+++ b/editor.scss
@@ -314,6 +314,7 @@ p.has-drop-cap:not(:focus)::first-letter {}
 
 .wp-block-file__textlink {
 	text-decoration: underline;
+	color: $x-color-secondary-base;
 }
 
 .wp-block-file .wp-block-file__button,

--- a/editor.scss
+++ b/editor.scss
@@ -30,20 +30,14 @@ $font-size-value: 18.672;
 }
 
 @mixin button-style() {
-	@include rounded( 3px );
 	background-color: $x-color-accent-base;
-	color: $x-color-shade-white;
-	font-size: $x-font-size-sm;
-	line-height: $x-font-leading-body;
-	letter-spacing: $x-font-letter-spacing;
-	padding: 0.675em 1.2em;
-	border: 0;
-	cursor: pointer;
-	display: inline-block;
-	font-weight: 600;
-	text-decoration: none;
 	text-transform: uppercase;
-	vertical-align: middle;
+	text-decoration: none;
+	font-weight: 600;
+	letter-spacing: $x-font-letter-spacing;
+	font-size: (15.56em / $font-size-value);
+	padding: 0.68em 1.2em;
+	border-radius: 3px;
 }
 
 /*--------------------------------------------------------------
@@ -279,11 +273,13 @@ p.has-drop-cap:not(:focus)::first-letter {}
 /* File */
 
 .wp-block-file__textlink {
-	/* Same as link styles */
+	text-decoration: underline;
 }
 
 .wp-block-file .wp-block-file__button,
-.wp-block-file .wp-block-file__button:visited {}
+.wp-block-file .wp-block-file__button:visited {
+	@include button-style;
+}
 
 .wp-block-file .wp-block-file__button:hover,
 .wp-block-file .wp-block-file__button:focus,
@@ -372,6 +368,16 @@ p.has-drop-cap:not(:focus)::first-letter {}
 
 .wp-block-button .wp-block-button__link {
 	@include button-style;
+}
+
+.wp-block-button.is-style-squared .wp-block-button__link  {
+	border-radius: 0;
+}
+
+.wp-block-button.is-style-outline .wp-block-button__link {
+	background: transparent;
+	border: solid 2px $x-color-accent-base;
+	color: $x-color-accent-base;
 }
 
 .wp-block-button .wp-block-button__link:hover,

--- a/editor.scss
+++ b/editor.scss
@@ -206,7 +206,7 @@ $font-size-value: 18.672;
 
 
 .wp-block-freeform.block-library-rich-text__tinymce ol,
-.editor-styles-wrapper ol {
+.editor-styles-wrapper ol:not([class^="wp-block"]) {
 	counter-reset: sans-counter;
 	margin-left: 0 !important;
 

--- a/editor.scss
+++ b/editor.scss
@@ -194,6 +194,12 @@ $font-size-value: 18.672;
 	}
 }
 
+.block-library-list .editor-rich-text__tinymce,
+.block-library-list .editor-rich-text__tinymce ol,
+.block-library-list .editor-rich-text__tinymce ul {
+	padding-left: 0.1em;
+}
+
 
 .wp-block-freeform.block-library-rich-text__tinymce ol,
 .editor-styles-wrapper ol {
@@ -369,9 +375,14 @@ p.has-drop-cap:not(:focus)::first-letter {}
 
 .wp-block-pullquote {
 	border: none;
+	margin-top: 0;
 	border-left: solid 4px $x-color-accent-base;
 	padding: 0;
 	text-align: left;
+	
+	blockquote {
+		margin-top: 0;
+	}
 }
 
 .wp-block-pullquote blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty=true]::before,
@@ -379,7 +390,7 @@ p.has-drop-cap:not(:focus)::first-letter {}
 	font-size: 22.4064em / $font-size-value;
 	color: $x-color-secondary-base;
 	font-style: italic;
-	margin-bottom: 0.7em;
+	margin-bottom: 0.45em;
 	padding-top: 0.2em;
 	line-height: 1.6
 }
@@ -502,6 +513,20 @@ p.has-drop-cap:not(:focus)::first-letter {}
 6.0 Blocks - Widgets
 --------------------------------------------------------------*/
 
+/* Latest Posts, Categories, Archives – Link Styles */
+
+/* Latest Posts */
+.wp-block-latest-posts,
+.wp-block-categories, 
+.wp-block-archives {
+	li {
+		margin: 0.3em 0;
+		a {
+			color: $x-color-secondary-base;
+		}
+	}
+}
+
 /* Categories, Latest Posts & Archives */
 
 [data-align="center"] .wp-block-categories ul,
@@ -538,7 +563,6 @@ p.has-drop-cap:not(:focus)::first-letter {}
 	/* selector for each individual comment - good for borders, padding */
 }
 
-/* Latest Posts */
 .edit-post-visual-editor .wp-block-latest-posts.is-grid {
 	list-style: none;
 	margin-left: 0;

--- a/editor.scss
+++ b/editor.scss
@@ -1,353 +1,468 @@
-/*!
-Business theme editor styles
+/*
+Theme Name: Business
+Description: Used to style Gutenberg Blocks in the editor.
 */
+
+/*--------------------------------------------------------------
+>>> TABLE OF CONTENTS:
+----------------------------------------------------------------
+1.0 General Typography
+2.0 General Block Settings
+3.0 Blocks - Common Blocks
+4.0 Blocks - Formatting
+5.0 Blocks - Layout Elements
+6.0 Blocks - Widgets
+
+--------------------------------------------------------------*/
 @import "stylesheets/variables/index";
 @import "stylesheets/inc/index";
 
+$font-size-value: 18.672;
+
 :root {}
 
-@import "stylesheets/typography";
-@import "stylesheets/elements-common";
-
-@import "css/blocks.scss";
-
-@mixin editor-font-base {
-	font-size: $x-font-size-base;
-
-	@include media(tablet) {
-		// font-size for tablet and up
-		font-size: calc( #{$x-font-size-base} * 0.95065 * #{$x-font-size-responsive-ratio} );
-	}
+@mixin block-quote-citation-style() {
+	color: $x-color-words-subtle !important;
+	font-size: $x-font-size-sm;
+	font-family: $x-font-family-heading;
+	font-style: normal;
+	text-transform: none;
 }
 
-.block-editor .edit-post-visual-editor, p {
-	@include editor-font-base;
-
-	h1, h2, h3, h4, h5, h6 {
-		margin-top: 0.83em;
-	}
-
+@mixin button-style() {
+	@include rounded( 3px );
+	background-color: $x-color-accent-base;
+	color: $x-color-shade-white;
+	font-size: $x-font-size-sm;
+	line-height: $x-font-leading-body;
+	letter-spacing: $x-font-letter-spacing;
+	padding: 0.675em 1.2em;
+	border: 0;
+	cursor: pointer;
+	display: inline-block;
+	font-weight: 600;
+	text-decoration: none;
+	text-transform: uppercase;
+	vertical-align: middle;
 }
 
-.block-editor-page {
-	@include media( desktop ) {
+/*--------------------------------------------------------------
+1.0 General Typography
+--------------------------------------------------------------*/
 
-		.editor-post-title {
-			margin: 0 auto;
-		}
-
-		.editor-post-title__block {
-			max-width: 740px !important;
-		}
-
-		.editor-post-title__input {
-
-		}
-
-
-	}
-}
-
-.wp-block-columns {
-
-	.editor-block-list__block {
-		margin-top: 1em;
-	}
-
-	p {
-		font-size: 0.810em;
-	}
-
-}
-
-[data-type="core/column"] {
-
-	.editor-block-list__block .wp-block-columns .editor-block-list__block {
-		outline: solid 2px red;
-		max-width: 100%;
-	}
-
-}
-
-.editor-block-list__block .wp-block-columns .editor-block-list__block
-
-
-.block-editor .editor-block-list__block blockquote p,
-.block-editor .editor-block-list__block blockquote.is-large p {
-	@include editor-font-base;
-	padding-left: 0;
-}
-
-.editor-block-list__layout > .editor-block-list__block > .editor-block-list__block-edit,
-.editor-block-list__layout > .editor-block-list__layout > .editor-block-list__block > .editor-block-list__block-edit,
-.editor-block-list__layout > .editor-default-block-appender__content {
-	margin-top: 0;
-	margin-bottom: 0;
-}
-
-.edit-post-visual-editor .editor-block-list__block[data-align=wide] {
-	max-width: $x-space-column-12;
-}
-
-.editor-default-block-appender input[type="text"].editor-default-block-appender__content,
-.editor-post-title .editor-post-title__input,
-.edit-post-visual-editor,
-.edit-post-visual-editor p {
+/* font-family */
+.edit-post-visual-editor .editor-block-list__block,
+.editor-default-block-appender input[type="text"].editor-default-block-appender__content {
 	font-family: $x-font-family-body;
 }
 
-.editor-post-title .editor-post-title__input {
-	font-size: $x-font-size-xl;
-	font-weight: 900;
-	line-height: 1.2;
-	margin-bottom: 1.85rem;
-	@include media( tablet ) {
-		font-size: calc( #{$x-font-size-xxxl} * 1.175 );
-	}
-}
-
-// Editor width.
-.editor-block-list__block {
-	margin: 0 auto;
-	@include media( desktop ) {
-		max-width: $x-grid-column-7;
-		min-width: 740px;
-	}
-}
-
-.wp-block-columns .editor-block-list__block {
-	min-width: auto;
-}
-
-.editor-block-list__block[data-type="core/table"] .wp-block-table {
-	max-width: 100%;
-}
-
-.editor-block-list__block[data-type="core/table"][data-align=center] table {
-	width: 100%;
-}
-
-// Line height.
-
-.editor-rich-text__tinymce.mce-content-body {
+/* font size & line height */
+.edit-post-visual-editor .editor-block-list__block,
+.edit-post-visual-editor .editor-block-list__block p,
+.editor-default-block-appender input[type="text"].editor-default-block-appender__content {
 	line-height: $x-font-leading-body;
+	font-size: $font-size-value * 1px;
+	font-weight: 400;
 }
 
-// Links.
-.editor-block-list__layout a {
-	@include link-underline;
+/* font color */
+.edit-post-visual-editor .editor-block-list__block {
+	color: $x-color-words-base;
 }
 
-// Links
-.editor-block-list__layout
+/* Post title fonts and colors */
+.editor-post-title__block .editor-post-title__input {
+	font-family: $x-font-family-heading;
+	line-height: $x-font-leading-heading;
+	color: $x-color-words-heading;
+	font-size: 2.90386875em;
+	font-weight: 800;
+}
 
-// List styles.
+/* Headings - applies to both Classic and Header blocks */
 
-.block-library-list {
+.edit-post-visual-editor h1,
+.wp-block-freeform.block-library-rich-text__tinymce h1,
+.edit-post-visual-editor h2,
+.wp-block-freeform.block-library-rich-text__tinymce h2,
+.edit-post-visual-editor h3,
+.wp-block-freeform.block-library-rich-text__tinymce h3,
+.edit-post-visual-editor h4,
+.wp-block-freeform.block-library-rich-text__tinymce h4,
+.edit-post-visual-editor h5,
+.wp-block-freeform.block-library-rich-text__tinymce h5,
+.edit-post-visual-editor h6,
+.wp-block-freeform.block-library-rich-text__tinymce h6 {
+	color: $x-color-words-heading;
+	font-weight: 800;
+}
 
-	.editor-rich-text__tinymce {
-		margin-left: 0;
-	}
+.edit-post-visual-editor h1,
+.wp-block-freeform.block-library-rich-text__tinymce h1 {
+	font-size: (38.7183em / $font-size-value );
+}
 
-	ol {
-		list-style: none;
+.edit-post-visual-editor h2,
+.wp-block-freeform.block-library-rich-text__tinymce h2 {
+	font-size: (32.2652em / $font-size-value );
+}
+
+.edit-post-visual-editor h3,
+.wp-block-freeform.block-library-rich-text__tinymce h3 {
+	font-size: (26.8877em / $font-size-value);
+}
+
+.edit-post-visual-editor h4,
+.wp-block-freeform.block-library-rich-text__tinymce h4,
+.edit-post-visual-editor h5,
+.wp-block-freeform.block-library-rich-text__tinymce h5,
+.edit-post-visual-editor h6,
+.wp-block-freeform.block-library-rich-text__tinymce h6 {
+	font-size: (22.4064em / $font-size-value );
+}
+
+
+/*--------------------------------------------------------------
+2.0 General Block Settings
+--------------------------------------------------------------*/
+
+/* Main content width */
+
+.wp-block {
+	/* max-width: XXX -- content width plus 30px to account for editor padding */
+	max-width: 740px;
+}
+
+/* Link styles */
+
+.edit-post-visual-editor a,
+.editor-block-list__block a,
+.wp-block-freeform.block-library-rich-text__tinymce a {}
+
+/* 
+* General HTML selectors, used for the Classic Block 
+*/
+
+/* Table styles */
+
+.wp-block-freeform.block-library-rich-text__tinymce table {}
+
+.rtl .wp-block-freeform.block-library-rich-text__tinymce td,
+.rtl .wp-block-freeform.block-library-rich-text__tinymce th {}
+
+/* Quote styles */
+.wp-block-freeform.block-library-rich-text__tinymce blockquote {}
+
+.wp-block-freeform.block-library-rich-text__tinymce blockquote p {}
+
+.wp-block-freeform.block-library-rich-text__tinymce blockquote cite {}
+
+.rtl .wp-block-freeform.block-library-rich-text__tinymce blockquote {}
+
+/* List styles */
+
+.wp-block-freeform.block-library-rich-text__tinymce li,
+.editor-styles-wrapper li {
+	margin-bottom: 0;
+}
+
+.wp-block-freeform.block-library-rich-text__tinymce ol,
+.wp-block-freeform.block-library-rich-text__tinymce ul,
+.editor-styles-wrapper ol,
+.editor-styles-wrapper ul {
+	&.editor-rich-text__tinymce {
 		padding-left: 0;
-		> li {
-
-				counter-increment: sans-counter;
-				position: relative;
-				padding-left: $x-space-md;
-
-				ol li {
-					padding-left: $x-space-md;
-				}
-
-				ul li {
-					padding-left: $x-space-sm;
-				}
-
-				&:before {
-					content: counter(sans-counter, decimal-leading-zero) "\00a0";
-					left: 0;
-					position: absolute;
-					top: $x-space-xxs;
-					color: $x-color-primary-base;
-					font-family: $x-font-family-heading;
-					font-size: $x-font-size-xs;
-					line-height: $x-font-leading-md;
-				}
-			}
 	}
 }
 
-.block-editor .wp-block-categories ul,
-.block-editor .wp-block-latest-posts,
-.block-editor ul.wp-block-archives {
-	padding-left: 0.5em;
-}
 
-[data-align="full"] {
-	.wp-block-categories ul,
-	.wp-block-latest-posts,
-	ul.wp-block-archives {
-		padding-left: $x-space-lg;
+.wp-block-freeform.block-library-rich-text__tinymce ol,
+.editor-styles-wrapper ol {
+	counter-reset: sans-counter;
+	margin-left: 0 !important;
+
+	> li {
+		position: relative;
+		counter-increment: sans-counter;
+		padding-left: $x-space-md;
+		list-style: none;
+
+		&:before {
+			content: counter(sans-counter, decimal-leading-zero) "\00a0";
+			left: 0;
+			position: absolute;
+			top: $x-space-xxs;
+			color: $x-color-primary-base;
+			font-family: $x-font-family-heading;
+			font-size: $x-font-size-xs;
+			line-height: $x-font-leading-md;
+		}
 	}
 }
 
-// Separators
+/* Code styles */
 
-hr {
+.wp-block-freeform.block-library-rich-text__tinymce code {}
+
+/* Caption styles */
+
+[class^="wp-block-"] figcaption {
+	color: $x-color-words-subtle;
+	font-size: $x-font-size-sm;
+	font-family: $x-font-family-heading;
+}
+
+.wp-block-gallery .blocks-gallery-image figcaption, 
+.wp-block-gallery .blocks-gallery-item figcaption {
+	color: $x-color-shade-white;
+}
+
+/* Definition List styles */
+
+.wp-block-freeform.block-library-rich-text__tinymce dt {
+	font-weight: bold;
+}
+
+/* Pre styles */
+
+.wp-block-freeform.block-library-rich-text__tinymce pre {}
+
+/*--------------------------------------------------------------
+3.0 Blocks - Common Blocks
+--------------------------------------------------------------*/
+
+/* Paragraph */
+
+p.has-drop-cap:not(:focus)::first-letter {}
+
+/* Quote */
+.wp-block-quote {
+	border-left: solid 4px $x-color-accent-base !important;
+	padding-left: 1.7em !important;
+	padding-right: 2em !important;
+
+	p {
+		font-size: $x-font-size-base;
+		color: $x-color-secondary-base;
+		font-style: italic;
+	}
+}
+
+.wp-block-quote:not(.is-large):not(.is-style-large) {}
+
+.wp-block-quote .wp-block-quote__citation {
+	@include block-quote-citation-style;
+}
+
+.wp-block-quote.is-large p,
+.wp-block-quote.is-style-large p {}
+
+.wp-block-quote.is-large .wp-block-quote__citation,
+.wp-block-quote.is-style-large .wp-block-quote__citation {}
+
+.rtl .editor-styles-wrapper .wp-block-quote,
+.rtl .wp-block-quote:not(.is-large):not(.is-style-large) {}
+
+/* Cover */
+
+.wp-block-cover {}
+
+.edit-post-visual-editor .editor-block-list__block .wp-block-cover-image .wp-block-cover-image-text,
+.edit-post-visual-editor .editor-block-list__block .wp-block-cover-image .wp-block-cover-text,
+.edit-post-visual-editor .editor-block-list__block .wp-block-cover-image h2,
+.edit-post-visual-editor .editor-block-list__block .wp-block-cover .wp-block-cover-image-text,
+.edit-post-visual-editor .editor-block-list__block .wp-block-cover .wp-block-cover-text,
+.edit-post-visual-editor .editor-block-list__block .wp-block-cover h2 {
+	font-size: 2.0em; /* Cover images inherit the paragraph size; this resets it */
+}
+
+/* File */
+
+.wp-block-file__textlink {
+	/* Same as link styles */
+}
+
+.wp-block-file .wp-block-file__button,
+.wp-block-file .wp-block-file__button:visited {}
+
+.wp-block-file .wp-block-file__button:hover,
+.wp-block-file .wp-block-file__button:focus,
+.wp-block-file .wp-block-file__button:active {}
+
+/*--------------------------------------------------------------
+4.0 Blocks - Formatting
+--------------------------------------------------------------*/
+
+/* Verse */
+
+.wp-block-verse {}
+
+.wp-block-verse pre {
+	padding: 0;
+}
+
+/* Code */
+
+.wp-block-code {
+	border: none;
+	border-radius: 0;
+}
+
+.wp-block-code textarea {
+	background: transparent;
+}
+
+/* Preformatted */
+
+.wp-block-preformatted {}
+
+/* Pullquote */
+
+.wp-block-pullquote {
+	border: none;
+	border-left: solid 4px $x-color-accent-base;
+	padding: 0;
+	text-align: left;
+}
+
+.wp-block-pullquote blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty=true]::before,
+.wp-block-pullquote blockquote >.editor-rich-text p {
+	font-size: 22.4064em / $font-size-value;
+	color: $x-color-secondary-base;
+	font-style: italic;
+	margin-bottom: 0.7em;
+	padding-top: 0.2em;
+	line-height: 1.6
+}
+
+.wp-block-pullquote.alignleft blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
+.wp-block-pullquote.alignright blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
+.wp-block-pullquote.alignleft blockquote > .editor-rich-text p,
+.wp-block-pullquote.alignright blockquote > .editor-rich-text p {
+	/* Font size */
+	margin-bottom: 0 !important;
+}
+
+.wp-block-pullquote cite,
+.wp-block-pullquote footer,
+.wp-block-pullquote__citation {
+	@include block-quote-citation-style;
+}
+
+/* Table */
+.wp-block-table {}
+
+.rtl .wp-block-table th {
+	text-align: right;
+}
+
+.wp-block-table__cell-content {
+	padding: 0.5em; /* removes/adjusts padding in editor per cell */
+}
+
+/*--------------------------------------------------------------
+5.0 Blocks - Layout Elements
+--------------------------------------------------------------*/
+
+/* Buttons */
+
+.wp-block-button {
+	margin-bottom: 0;
+}
+
+.wp-block-button .wp-block-button__link {
+	@include button-style;
+}
+
+.wp-block-button .wp-block-button__link:hover,
+.wp-block-button .wp-block-button__link:focus,
+.wp-block-button .wp-block-button__link:active {}
+
+.wp-block-button .editor-rich-text__tinymce.mce-content-body {
+	/* Set a line-height here, if the button height changes when you edit it */
+}
+
+/* Separator */
+
+.wp-block-separator {
+	margin-top: $x-space-md !important;
+	margin-bottom: $x-space-md !important;
+	padding: 0;
+	width: 100px;
+	
 	background-color: $x-color-shade-gray-2;
 	border: 0;
 	height: 3px;
 	margin-bottom: 1.5em;
-}
 
-// Blockquote
-
-.edit-post-visual-editor .editor-block-list__block[data-align=full] {
-	> .editor-block-list__block-edit {
-		margin-left: 0;
-		margin-right: 0;
+	&.is-style-wide {
+		width: 100%;
 	}
 
-	.wp-block-pullquote blockquote {
-		max-width: calc( 100vw - 2em );
-	}
-}
+	&.is-style-dots {
+		background-color: $x-color-shade-white;
+		width: auto;
 
-.wp-block-pullquote blockquote >.block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty=true]:before,
-.wp-block-pullquote blockquote>.editor-rich-text p {
-	font-size: calc( #{$x-font-size-md} * 1.056 );
-}
-
-blockquote {
-
-	max-width: 1100px;
-	margin: 0 auto;
-	border-left-color: $x-color-accent-base !important;
-
-	&.wp-block-quote.is-style-large {
-		padding-left: $x-space-xl;
-	}
-
-	&.wp-block-quote,
-	&.wp-block-quote.is-large,
-	&.wp-block-quote.is-style-large {
-
-		@include media(tablet) {
-			margin-right: 0;
+		&:before {
+			content: "\00b7 \00b7 \00b7 \00b7 \00b7";
+			color: $x-color-shade-gray-4;
+			font-family: $body-font; /* family@include globalvar(font-family, body); */
+			font-size: $x-font-size-lg;
+			letter-spacing: 1em;
+			padding-left: 1em;
 		}
 	}
 
-	.wp-block-quote__citation {
-//		padding-left: $x-space-sm;
+	@include media( tablet ) {
+		&.is-style-dots {
+			max-width: $x-grid-column-6;
+		}
 	}
 }
 
-// Pull quote
+/*--------------------------------------------------------------
+6.0 Blocks - Widgets
+--------------------------------------------------------------*/
 
-.wp-block-pullquote {
-	border-bottom: none;
-	border-top: none;
+/* Categories, Latest Posts & Archives */
+
+[data-align="center"] .wp-block-categories ul,
+[data-align="center"] ul.wp-block-latest-posts,
+[data-align="center"] ul.wp-block-archives {
+	list-style-position: inside; /* makes sure bullets are centred with centred lists */
 }
 
-// Columns
+/* Latest Comments */
 
-.wp-block-text-columns,
-.wp-block-columns {
-	@include media(tablet) {
-		margin-right: 0;
-	}
-}
-
-// Images
-
-.wp-block-image {
-	figcaption {
-		margin-top: 0.8em;
-	}
-}
-
-// Tables
-.wp-block-table td ,
-.wp-block-table th {
-	border-width: 0;
-}
-
-// Latest Posts
-
-.wp-block-categories,
-.wp-block-archives,
-.wp-block-latest-posts,
 .wp-block-latest-comments {
-	font-size: calc( #{$x-font-size-md} * 0.86 );
-	li a {
-		@include link-underline;
-	}
+	margin-left: 0;
+	margin-right: 0;
 }
 
-.wp-caption .wp-caption-text,
-.wp-block-audio figcaption,
-.wp-block-video figcaption,
-.wp-block-image figcaption,
-.wp-block-gallery .blocks-gallery-image figcaption,
-.wp-block-gallery .blocks-gallery-item figcaption,
-.wp-block-quote .wp-block-quote__citation,
-.wp-block-pullquote .wp-block-pullquote__citation,
-.wp-block-pullquote cite {
-	font-size: calc( #{$x-font-size-sm} * 1.05 );
+.wp-block-latest-comments.aligncenter.has-avatars {}
+
+.wp-block-latest-comments.alignfull {}
+
+.wp-block-latest-comments__comment-meta,
+.wp-block-latest-comments__comment-excerpt p {
+	/* change font size */
 }
 
-.wp-block-gallery .blocks-gallery-item figcaption {
-	margin-bottom: -10px;
+.wp-block-latest-comments__comment-meta a {
+	/* change comment author name and post title styles */
 }
 
-.wp-block-gallery.alignfull {
-	max-width: 100%;
-	width: calc( 100% - 2 * 1em );
-	margin: 0 auto;
+.wp-block-latest-comments__comment-date {
+	/* change comment date styles */
 }
 
-.edit-post-visual-editor .editor-block-list__block[data-align=full] {
-	padding: 0;
+.wp-block-latest-comments .wp-block-latest-comments__comment {
+	/* selector for each individual comment - good for borders, padding */
 }
 
-.wp-block-quote.is-style-default .wp-block-quote__citation {
-	font-size: calc( #{$x-font-size-sm} * 1.1205 );
-}
-
-.wp-block-quote:not(.is-large):not(.is-style-large) {
-	padding-left: calc( #{$x-space-lg} * 0.75 );
-}
-
-.block-editor .editor-block-list__block blockquote.wp-block-quote.is-style-large {
-	padding-left: $x-space-md;
-	p {
-		font-size: calc( #{$x-font-size-lg} * 1.10 );
-	}
-	.wp-block-quote__citation {
-		font-size: $x-font-size-md;
-	}
-}
-
-.editor-block-list__block[data-type="core/paragraph"] a {
-	@include link-underline;
-}
-
-.editor-block-list__block[data-type="core/separator"] {
-	margin-top: $x-space-lg;
-	margin-bottom: $x-space-lg;
-}
-
-.block-editor .editor-block-list__block .wp-block-image .components-autocomplete {
-	font-size: calc( #{$x-font-size-xs} * 1.1 );
-}
-
-[data-type="core/image"][data-align="center"] .wp-block-image figcaption {
-	margin-top: 0.2em;
-}
-
-[data-type="core/image"] figcaption {
-	font-size: calc( #{$x-font-size-md} * 0.98 ) !important;
+/* Latest Posts */
+.edit-post-visual-editor .wp-block-latest-posts.is-grid {
+	list-style: none;
+	margin-left: 0;
+	margin-right: 0;
 }

--- a/editor.scss
+++ b/editor.scss
@@ -48,6 +48,10 @@ $font-size-value: 18.672;
 	font-size: (15.56em / $font-size-value);
 	padding: 0.68em 1.2em;
 	border-radius: 3px;
+	
+	&:hover {
+		background-color: lighten(  $x-color-accent-base, 6% );
+	}
 }
 
 /*--------------------------------------------------------------
@@ -461,6 +465,11 @@ p.has-drop-cap:not(:focus)::first-letter {}
 	background: transparent;
 	border: solid 2px $x-color-accent-base;
 	color: $x-color-accent-base;
+	
+	&:hover {
+		background: $x-color-accent-base;
+		color: white;
+	}
 }
 
 .wp-block-button .wp-block-button__link:hover,

--- a/editor.scss
+++ b/editor.scss
@@ -50,7 +50,7 @@ $font-size-value: 18.672;
 	border-radius: 3px;
 	
 	&:hover {
-		background-color: lighten(  $x-color-accent-base, 6% );
+		background-color: lighten(  $accent-color, 6% );
 	}
 }
 

--- a/editor.scss
+++ b/editor.scss
@@ -423,6 +423,7 @@ p.has-drop-cap:not(:focus)::first-letter {}
 	th {
 		padding: .5em;
 		text-align: left;
+		border-color: transparent;
 	}
 
 	tr:nth-child(even) {

--- a/editor.scss
+++ b/editor.scss
@@ -21,6 +21,16 @@ $font-size-value: 18.672;
 
 :root {}
 
+@mixin alignleft {
+	margin-right: $x-space-md;
+	margin-bottom: $x-space-sm;
+}
+
+@mixin alignright {
+	margin-left: $x-space-md;
+	margin-bottom: $x-space-sm;
+}
+
 @mixin block-quote-citation-style() {
 	color: $x-color-words-subtle !important;
 	font-size: $x-font-size-sm;
@@ -43,6 +53,11 @@ $font-size-value: 18.672;
 /*--------------------------------------------------------------
 1.0 General Typography
 --------------------------------------------------------------*/
+
+/* Links */
+.editor-rich-text__tinymce a {
+	color: $x-color-secondary-base;
+}
 
 /* font-family */
 .edit-post-visual-editor .editor-block-list__block,
@@ -107,12 +122,22 @@ $font-size-value: 18.672;
 }
 
 .edit-post-visual-editor h4,
-.wp-block-freeform.block-library-rich-text__tinymce h4,
+.wp-block-freeform.block-library-rich-text__tinymce h4 {
+	font-size: (22.4064em / $font-size-value );
+}
+
 .edit-post-visual-editor h5,
-.wp-block-freeform.block-library-rich-text__tinymce h5,
+.wp-block-freeform.block-library-rich-text__tinymce h5 {
+	font-size: (15.498em / $font-size-value );
+	letter-spacing: 0.125em;
+	text-transform: uppercase;
+}
+
 .edit-post-visual-editor h6,
 .wp-block-freeform.block-library-rich-text__tinymce h6 {
-	font-size: (22.4064em / $font-size-value );
+	font-size: (12.5102em / $font-size-value );
+	letter-spacing: 0.125em;
+	text-transform: uppercase;
 }
 
 
@@ -249,10 +274,15 @@ p.has-drop-cap:not(:focus)::first-letter {}
 }
 
 .wp-block-quote.is-large p,
-.wp-block-quote.is-style-large p {}
+.wp-block-quote.is-style-large p {
+	font-size: (26.89em/$font-size-value);
+}
 
 .wp-block-quote.is-large .wp-block-quote__citation,
-.wp-block-quote.is-style-large .wp-block-quote__citation {}
+.wp-block-quote.is-style-large .wp-block-quote__citation {
+	font-size: (20.61em/$font-size-value);
+	margin-top: -0.8em;
+}
 
 .rtl .editor-styles-wrapper .wp-block-quote,
 .rtl .wp-block-quote:not(.is-large):not(.is-style-large) {}
@@ -513,4 +543,14 @@ p.has-drop-cap:not(:focus)::first-letter {}
 	list-style: none;
 	margin-left: 0;
 	margin-right: 0;
+}
+
+/* Left aligned block */
+.editor-block-list__layout .editor-block-list__block[data-align=left] .editor-block-list__block-edit {
+	@include alignleft;
+}
+
+/* Right aligned block */
+.editor-block-list__layout .editor-block-list__block[data-align=right] .editor-block-list__block-edit {
+	@include alignright;
 }

--- a/editor.scss
+++ b/editor.scss
@@ -423,7 +423,6 @@ p.has-drop-cap:not(:focus)::first-letter {}
 	th {
 		padding: .5em;
 		text-align: left;
-		border-color: rgba( gray, 0.12 );
 	}
 
 	tr:nth-child(even) {

--- a/editor.scss
+++ b/editor.scss
@@ -289,10 +289,6 @@ p.has-drop-cap:not(:focus)::first-letter {}
 4.0 Blocks - Formatting
 --------------------------------------------------------------*/
 
-/* Verse */
-
-.wp-block-verse {}
-
 .wp-block-verse pre {
 	padding: 0;
 }
@@ -300,17 +296,44 @@ p.has-drop-cap:not(:focus)::first-letter {}
 /* Code */
 
 .wp-block-code {
+	background-color: $x-color-shade-gray-2;
 	border: none;
 	border-radius: 0;
+	
+	.editor-plain-text {
+		color: $x-color-words-base;
+		padding: 0.5em 0.5em 0.2em;
+	}
 }
 
 .wp-block-code textarea {
 	background: transparent;
 }
 
+/* Verse */
+
+.wp-block-verse {
+	font-family: $x-font-family-code;
+	background-color: $x-color-shade-gray-2;
+	padding: 1em 1em;
+	
+	.editor-rich-text__tinymce {
+		color: $x-color-words-base;
+		font-size: (15.56em/$font-size-value);
+		line-height: 1.6 !important;
+	}
+}
+
 /* Preformatted */
 
-.wp-block-preformatted {}
+.wp-block-preformatted {
+	background-color: $x-color-shade-gray-2;
+	padding: 1em 1em;
+	
+	.editor-rich-text__tinymce {
+		color: $x-color-words-base;
+	}
+}
 
 /* Pullquote */
 
@@ -346,14 +369,33 @@ p.has-drop-cap:not(:focus)::first-letter {}
 }
 
 /* Table */
-.wp-block-table {}
+.wp-block-table {
+
+	overflow-x: auto;
+
+	td,
+	th {
+		padding: .5em;
+		text-align: left;
+		border-color: rgba( gray, 0.12 );
+	}
+
+	tr:nth-child(even) {
+		background-color: $x-color-shade-gray-2;
+	}
+
+	thead tr:nth-child(odd) {
+		background-color: $x-color-primary-bg;
+	}
+	
+}
 
 .rtl .wp-block-table th {
 	text-align: right;
 }
 
 .wp-block-table__cell-content {
-	padding: 0.5em; /* removes/adjusts padding in editor per cell */
+	padding: 0; /* removes/adjusts padding in editor per cell */
 }
 
 /*--------------------------------------------------------------

--- a/functions.php
+++ b/functions.php
@@ -75,9 +75,6 @@ if ( ! function_exists( 'business_theme_setup' ) ) :
 		// Add support for core editor styles
 		add_theme_support( 'editor-styles' );
 
-		// Add support for custom editor styles
-		add_editor_style( 'editor.css' );
-
 		// Add support for custom color scheme.
 		add_theme_support( 'editor-color-palette', array(
 			array(

--- a/stylesheets/_elements-common.scss
+++ b/stylesheets/_elements-common.scss
@@ -61,7 +61,7 @@ blockquote.is-large {
 	
 	p {
 		margin: 0;
-		padding: $x-space-xs 0;
+		padding: 0.4em 0;
 		word-break: break-word;
 	}
 

--- a/stylesheets/_entries.scss
+++ b/stylesheets/_entries.scss
@@ -243,8 +243,8 @@
 		span[id^=more] {
 			display: block;
 		}
-
-		a:not(.jp-relatedposts-post-a):not(.wp-block-button__link) {
+		
+		*:not([class^="wp-block"]) a:not(.jp-relatedposts-post-a) {
 			@include link-underline;
 		}
 

--- a/stylesheets/_entries.scss
+++ b/stylesheets/_entries.scss
@@ -244,7 +244,7 @@
 			display: block;
 		}
 
-		a:not(.jp-relatedposts-post-a) {
+		a:not(.jp-relatedposts-post-a):not(.wp-block-button__link) {
 			@include link-underline;
 		}
 

--- a/stylesheets/_layout.scss
+++ b/stylesheets/_layout.scss
@@ -2,6 +2,7 @@
 /** === Layout === */
 
 #page {
+	overflow-x: hidden;
 	width: 100%;
 }
 

--- a/stylesheets/_typography.scss
+++ b/stylesheets/_typography.scss
@@ -59,27 +59,23 @@ big {
 }
 
 h2,
-.text--xl,
-.has-larger-font-size {
+.text--xl {
 	font-size: $x-font-size-xl;
 }
 
 .site-title,
 h3,
-.text--lg,
-.has-large-font-size {
+.text--lg {
 	font-size: $x-font-size-lg;
 }
 
 h4,
-.text--md,
-.has-regular-font-size {
+.text--md,{
 	font-size: $x-font-size-md;
 }
 
 .text--sm,
-small,
-.has-small-font-size {
+small {
 	font-size: $x-font-size-sm;
 }
 

--- a/stylesheets/_typography.scss
+++ b/stylesheets/_typography.scss
@@ -94,7 +94,7 @@ dfn, em, i {
 blockquote,
 blockquote.is-large {
 
-	border-left: 4px solid grey;
+	border-left: 4px solid transparent;
 	border-left-color: $x-color-accent-base;
 
 	p {

--- a/stylesheets/inc/_mixins.scss
+++ b/stylesheets/inc/_mixins.scss
@@ -115,8 +115,8 @@ $wide_width: 12 * ( 80px + 25px ) - 25px;
 	text-transform: uppercase;
 	vertical-align: middle;
 	
-	&:hover {
-		background-color: $x-color-accent-light;
+	&:hover, .wp-block-button__link:hover {
+		background-color: lighten(  $x-color-accent-base, 6% ) ;
 	}
 
 	&:active,

--- a/stylesheets/inc/_mixins.scss
+++ b/stylesheets/inc/_mixins.scss
@@ -116,7 +116,7 @@ $wide_width: 12 * ( 80px + 25px ) - 25px;
 	vertical-align: middle;
 	
 	&:hover, .wp-block-button__link:hover {
-		background-color: lighten(  $x-color-accent-base, 6% ) ;
+		background-color: lighten(  $accent-color, 6% ) ;
 	}
 
 	&:active,

--- a/stylesheets/inc/_mixins.scss
+++ b/stylesheets/inc/_mixins.scss
@@ -97,3 +97,34 @@ $wide_width: 12 * ( 80px + 25px ) - 25px;
 		font-size: calc( #{$x-font-size-base} * #{$x-font-size-responsive-ratio} ); // 1 1/6
 	}
 }
+
+@mixin button-style {
+	@include rounded( 3px );
+	background: $x-color-accent-base;
+	color: $x-color-shade-white;
+	padding: $x-space-xxs $x-space-xs;
+	font-size: $x-font-size-sm;
+	line-height: $x-font-leading-body;
+	letter-spacing: $x-font-letter-spacing;
+	background-image: none;
+	border: 0;
+	cursor: pointer;
+	display: inline-block;
+	font-weight: 600;
+	text-decoration: none;
+	text-transform: uppercase;
+	vertical-align: middle;
+	
+	&:hover {
+		background-color: $x-color-accent-light;
+	}
+
+	&:active,
+	&:focus {
+		background-color: $x-color-accent-light;
+	}
+
+	@include media( tablet ) {
+		padding: $x-space-xs $x-space-sm;
+	}
+}


### PR DESCRIPTION
### Overview

This is a complete rewrite of the editor styles for the Business theme.

The previous styles have been completely discarded and the new editor styles have been created from scratch. Several of the reported issues have already been fixed by this rewrite.

Also, the enqueuing of editor styles has been refactored to remove the redundancy (as reported in #15), which was causing all the trouble in the editor styles currently.

The code uses the work by @laurelfulford on [Automattic/theme-tools](https://github.com/Automattic/theme-tools/tree/master/gutenberg-stylesheets), which provides a good starting point for the editor styles.

_Related issues: #10, #12, #13, #14, #15_ 

- - -

### Installation Instructions

Start by cloning the branch:

    git clone --depth=1 git@github.com:Automattic/default-small-business-theme.git -b fix/base-editor-styles

Install dependencies and build theme:

    make deps build

At this point, theme should be ready for testing.

- - -

### Testing Instructions

Use the testing approach of your preference.

Our [gutenberg-test-data](https://github.com/Automattic/theme-tools/tree/master/gutenberg-test-data) can be used for testing.
