### PR TITLE
Add missing margin to social navigation menu items

### DIFF
--- a/stylesheets/_site-navigation.scss
+++ b/stylesheets/_site-navigation.scss
@@ -368,6 +368,12 @@
 				display: none;
 			}
 
+			&:nth-child(n+2) {
+				@include media( mobile ) {
+					margin-left: 0.7em;
+				}
+			}
+
 			a {
 				display: inline-block;
 				line-height: 1;


### PR DESCRIPTION
Fixes issue in which social menu items do not have a margin assigned.

- - -
See [Automattic/themes#331](https://github.com/Automattic/themes/issues/331)